### PR TITLE
Minor typo fixes in documentation and adding pip to environment.yaml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 We are so glad that you want to contribute to our project! Here are some guidelines to help you get started:
 
 We are using git for version control, if you are familiar with git feel free to skip this section. The first thing you will
-need is a github account. If you don't have one, you can create one at [github.com](github.com). After that you can fork the 
+need is a github account. If you don't have one, you can create one at [github.com](github.com). After that you can fork the
 repository by clicking the "Fork" button in the top right corner of the repository page. This will create a copy of the repository in your own account.
 
 Here are some basic git instuctions:
@@ -15,7 +15,7 @@ Here are some basic git instuctions:
 ## Creating a local git repo
 
 Github is built on top of git. Git is a popular code version control system that tracks your edits to files and whether
-new files are added or old ones are delelted. To create a git repository in a directory of your choosing
+new files are added or old ones are deleted. To create a git repository in a directory of your choosing
 
 ```bash
 cd mydirectory
@@ -69,10 +69,10 @@ and you can push using
 git push -u origin <branch name>
 ```
 
-Please create a `.gitignore` file to keep the unwanted from being added and commited to the repository. You can also use the 
-exisiting file and make changes as you see fit. 
+Please create a `.gitignore` file to keep the unwanted from being added and committed to the repository. You can also use the
+existing file and make changes as you see fit.
 
-### Commiting guidelines
+### Committing guidelines
 
 Please make sure to write clear and concise commit messages. A good commit message should explain what changes were made and why.
 Do not try to make multiple unrelated changes in a single commit. Instead, break them down into smaller, logical commits, this not only
@@ -83,21 +83,21 @@ allow us to review and merge them independently, making the process smoother and
 ### Branching guidelines
 
 When you are working on a new feature or bug fix, please create a new branch for your changes. This will help keep the main branch clean and will also
-avoid conflicts with other contributors. 
+avoid conflicts with other contributors.
 
 ## Code Style
 
 As you can tell this is mainly a Python project, so please follow the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide for Python code.
-To make everyone's life easier we are going to keep a very relaxed style guide. We are not going to enforce any specific line length, or any specific 
+To make everyone's life easier we are going to keep a very relaxed style guide. We are not going to enforce any specific line length, or any specific
 indentation style. We do however ask that you use spaces instead of tabs for indentation, and that you use 4 spaces for each level of indentation.
 
-Find a clear but short name for your task obviously `myawesomecode` is not an appropritae name for a folder or python
+Find a clear but short name for your task obviously `myawesomecode` is not an appropriate name for a folder or python
 code but neither is `scibertsummarizerforclinicalnotesbasedonpreviouscomments`. Something like `summarizer` is a much
 better choice. While naming folders and files try and be as explicit as possible so if your code does not summarize but
 select sections of notes `section_selector` might be more suitable.
 
 Within each folder there should be at least one python module with the same name, this module will contain the main code
-that does the task. This does not mean that it will contain **all** the code related to the task. Have a clear separtion
+that does the task. This does not mean that it will contain **all** the code related to the task. Have a clear separation
 of different kinds of things each module does and try to contain each of these in their respective module. You can
 make this as a CLI script that is callable with arguments (see below) or you can choose to include another file
 (this can be python or bash -let's keep things standard, if you use bash please set `-oe pipefail`).
@@ -107,14 +107,14 @@ that are helper functions and classes but do not perform the main task. For exam
 tab (`\t`) and converts them to new lines (`\n`) will be in the utils.
 
 If this module is going to be part of the knowledge base and will be used by other modules, please make sure that you describe
-in detail how it works and what it does in the `README.md` file. 
+in detail how it works and what it does in the `README.md` file.
 
 Additionally you will need to structure your data in a way that it can be stored in a normalized SQL database. This means that
 you will need to create a module called tables.py and that will contain the SQLAlchemy models that will be used to generate and
 populate the tables in the database. Some of the modules already have this files, so feel free to use them as a reference.
 
 If you are not familiar with SQLAlchemy, please take a look at the [SQLAlchemy documentation](https://docs.sqlalchemy.org/en/14/orm/tutorial.html) and
-if you have any questions about how to sructure your data in a way that it can be stored in a normalized SQL database, see 
+if you have any questions about how to sructure your data in a way that it can be stored in a normalized SQL database, see
 [here](https://www.datacamp.com/tutorial/normalization-in-sql) for reference and you can always reach out to us via issues.
 
 There is no limit to how many modules you can create but one helpful rule I find is to focus on the task not on the
@@ -130,7 +130,7 @@ document will include:
 + detailed description of modules
 + usage instructions for main classes and functions
 
-If you are using conda you can choose to inlcude an `enviroment.yaml`. Please use these names in and not something else
+If you are using conda you can choose to include an `enviroment.yaml`. Please use these names in and not something else
 to make sure that we are all in the same page.
 
 ## Code style
@@ -188,8 +188,8 @@ that's ok too but with complexity comes side effects and convoluted code. If you
 features please feel free to reach out and we can discuss if we can have a simpler architecture.
 
 If you like using type hints please do so, but do not feel obligated to use them. If you do use them please make sure that
-the types are correct and that they are used consistently throughout the codebase. Whenever applicaple at least describe
-what types are expected for the inputs and outputs of the functions within the docstring. 
+the types are correct and that they are used consistently throughout the codebase. Whenever applicable at least describe
+what types are expected for the inputs and outputs of the functions within the docstring.
 
 
 ### Lazy vs Eager eval
@@ -224,7 +224,7 @@ VM (not a big deal it just would take a bit for me to reset and everyone will be
 ### Arguments and settings
 
 For simple CLI arguments use the `argparse` module. This is an extremely flexible module and you can have subparsers
-for different modes of analysis. Please do not use a 3rd parth module like `click`. There is no need to increase the
+for different modes of analysis. Please do not use a 3rd party module like `click`. There is no need to increase the
 number of dependencies.
 
 If your code requires extensive parameters (it might for experimentation) you can have a `json` or a `yaml` file to
@@ -241,27 +241,27 @@ as well.
 
 If you want to contribute to someone else's code please create a pull request unless you are actively working with
 that person. The tagged person will then review the code and will approve or edit as they see fit. Save for the
-simplest of taskt please keep the discussion within the issues section so we all know what's going on.
+simplest of tasks please keep the discussion within the issues section so we all know what's going on.
 
 I'm excited to work with you all on this project and sorry for the wall of text. I hope this was not all boring for
-you and it will be a good learning experience for all of us. Please let me know if you run into git issues and need 
-some config help. 
+you and it will be a good learning experience for all of us. Please let me know if you run into git issues and need
+some config help.
 
 ## Docker/singularity containers
 
-If you are using docker or singularity containers please make sure that you have a `Dockerfile` or a `Singularity` file. 
+If you are using docker or singularity containers please make sure that you have a `Dockerfile` or a `Singularity` file.
 Additionally your containers not only should have all the dependencies installed but also should be able to run using the code
-and files that are inside the container. This means that if you are using any kind of AI models you should download and inlcude the
-model weights within the container. While this will make the container larger it will also make it easier to use for other people. 
+and files that are inside the container. This means that if you are using any kind of AI models you should download and include the
+model weights within the container. While this will make the container larger it will also make it easier to use for other people.
 
 For each container please include a `README.md` file that describes how to build and run the container. This should include:
 
 + How the container can be built (as simple as Dockerfile will be enough)
 + Which command(s) to use to run the container
 
-Avoid including complicated pipelines inside the container. It is possible to generate a pipline using a series of contianers
+Avoid including complicated pipelines inside the container. It is possible to generate a pipeline using a series of containers
 this will also make it easier to use/maintain and modularize. For simple things like running multiple QC metrics for an RNA-Seq
 pipeline you can use a single container that has all the dependencies installed.
 
-If you are generating a pipeline using multiple containers please include a `README.md` file that describes how to use the pipeline. 
-Use WDL or Snakemake to generate the pipeline. Your rules should clearly state which containers map to which rules. 
+If you are generating a pipeline using multiple containers please include a `README.md` file that describes how to use the pipeline.
+Use WDL or Snakemake to generate the pipeline. Your rules should clearly state which containers map to which rules.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,14 +7,14 @@
 We are so glad that you want to contribute to our project! Here are some guidelines to help you get started:
 
 We are using git for version control, if you are familiar with git feel free to skip this section. The first thing you will
-need is a github account. If you don't have one, you can create one at [github.com](github.com). After that you can fork the
+need is a GitHub account. If you don't have one, you can create one at [github.com](github.com). After that you can fork the
 repository by clicking the "Fork" button in the top right corner of the repository page. This will create a copy of the repository in your own account.
 
-Here are some basic git instuctions:
+Here are some basic git instructions:
 
 ## Creating a local git repo
 
-Github is built on top of git. Git is a popular code version control system that tracks your edits to files and whether
+GitHub is built on top of git. Git is a popular code version control system that tracks your edits to files and whether
 new files are added or old ones are deleted. To create a git repository in a directory of your choosing
 
 ```bash
@@ -114,7 +114,7 @@ you will need to create a module called tables.py and that will contain the SQLA
 populate the tables in the database. Some of the modules already have this files, so feel free to use them as a reference.
 
 If you are not familiar with SQLAlchemy, please take a look at the [SQLAlchemy documentation](https://docs.sqlalchemy.org/en/14/orm/tutorial.html) and
-if you have any questions about how to sructure your data in a way that it can be stored in a normalized SQL database, see
+if you have any questions about how to structure your data in a way that it can be stored in a normalized SQL database, see
 [here](https://www.datacamp.com/tutorial/normalization-in-sql) for reference and you can always reach out to us via issues.
 
 There is no limit to how many modules you can create but one helpful rule I find is to focus on the task not on the
@@ -233,7 +233,7 @@ argument in the callable script.
 
 ### Push guides
 
-As long as you are following the guidelines above you can push to your branches as much as you want. Github tracks
+As long as you are following the guidelines above you can push to your branches as much as you want. GitHub tracks
 your git repo so if you have done multiple commits a single push will show up as multiple commits on the remote repo
 as well.
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -24,7 +24,7 @@ Here are the instructions for installation.
 git clone https://github.com/ccmbioinfo/ccm_benchmate
 
 # go into the directory
-cd benchmate
+cd ccm_benchmate
 
 #create the conde env
 conda env create -f environment.yaml #this might take a minute or 2

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -11,7 +11,7 @@ we add more functionalities and move some of them to the `ContainerRunner` modul
 ## Installing Conda
 
 This one is fairly straightforward, you can follow the instructions [here]() after running the installation script you should
-be able to activate/deactivate conda environments. If you are installing this under HPC, I suggest that you move the locaiton
+be able to activate/deactivate conda environments. If you are installing this under HPC, I suggest that you move the location
 of your conda cache to a different location. You can do that by following the instructions [here](), the other option
 is that you can create a [symbolic link]() to your `.cache`, `.singularity` and `.conda` folders in your `~` where the actual
 folders are in a partition with more storage. 
@@ -36,13 +36,11 @@ pip install -r requirements.txt
 pip install . 
 ```
 
-
-
 This will create the conda environment and install all the dependencies. There are a few things to keep in mind which are 
 not included in this package yet and there are some gotchas:
 
 1. MMSEQS requires AVX512 instruction sets. If you have a new-ish personal computer, that should be fine. It might not run on 
-apple silicon, I have not tested that. Additionally, some of the older cpus on HPC do not support this. You will need to 
+apple silicon, I have not tested that. Additionally, some of the older CPUs on HPC do not support this. You will need to 
 create a job where you specify this constraint by including `-constraint=avx512`
 
 2. Singularity is not included in this package, however, there is an instance of singularity and another one of apptainer

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ as well as their own data.
 To get started please see [installation instructions](INSTALLATION.md).
 
 Each of the modules are designed to work independently from one another with few exceptions (see variant and ranges modules 
-and how they are used in the apis and genome module). Each module has its own README file that provides usage instructions and 
+and how they are used in the APIs and genome module). Each module has its own README file that provides usage instructions and 
 how they can be integrated together. 
 
 This package is a work in progress and is not yet ready for production use, that said, quite a few of the modules can be 
@@ -52,37 +52,37 @@ useful for retrieving articles that you already know about or more importantly a
 apis modules. 
 
 Articles titles and abstracts are returned as from pubmed and arxiv searches (pubmed already archives medarxiv and bioarxiv articles).
-Additionally you can search for open acceess articles using openalex.org and retrieve their full text pdf files for download. 
+Additionally you can search for open access articles using openalex.org and retrieve their full text pdf files for download. 
 
 These downloaded pdf (as well as any other local pdf that you already have) can be processed to extract the text, figures, tables from the 
-downloaded documents. Using semantich chunking methods (sepearing the text into sections that convey similar topics) the text can further be
-processed. Figures and tables can be automaticall interpreted using a vision language model (default is QWEN-7.5B-VL). These interpretations 
-are similarly processed to the full text data. All of this can be permanantly stored in a database for later retrieval and analysis 
+downloaded documents. Using semantic chunking methods (separating the text into sections that convey similar topics) the text can further be
+processed. Figures and tables can be automatically interpreted using a vision language model (default is QWEN-7.5B-VL). These interpretations 
+are similarly processed to the full text data. All of this can be permanently stored in a database for later retrieval and analysis 
 (more on that later, see knowledge_base module). 
 
 ## Container Runner module:
 
-This is a module that would allow you to run any conteinerized application on your local machine or on a remote server. To give you the most
-flexible way to incoporate your data into you database we have created a container runner class that can be used to run any singularity/apptainer
-containter either locally or on HPC. We also have a to_container script that can be used to convert conda environments into singularity/appatiner
-contianers. 
+This is a module that would allow you to run any containerized application on your local machine or on a remote server. To give you the most
+flexible way to incorporate your data into you database we have created a container runner class that can be used to run any singularity/apptainer
+container either locally or on HPC. We also have a to_container script that can be used to convert conda environments into singularity/appatiner
+containers. 
 
-We are working on creating a small libarry of exisiting containers that can be immediately used to process your data. These will be available 
+We are working on creating a small library of existing containers that can be immediately used to process your data. These will be available 
 soon in our own docker container registry. You can then use these docker containers to create a singluarity/apptainer .sif file to run arbitrary packages and pipelines. You can run these packages and commands either in an interactive session or submit them as slurmm jobs in HPC. Please see the container runner module readme for usage instructions. 
 
 Keep in mind that if you want to integrate the outputs of these containers/pipelines it's up to you to make sure that they are compatible with the modules in this package. 
 
 ## Databases Module
 
-Currently this is empty, the goal is to gather information and requests from the general community to create either a standalone database with a query schema or just a collection of read-only file where users can search for their data on their own. Once this is done we will also release the files and their respective contents available here that are under hpc. Additionally we will provide a download script to create the same folder/database structure as well as instructions to how to regularly update the files as new versions of databases become available. 
+Currently this is empty, the goal is to gather information and requests from the general community to create either a standalone database with a query schema or just a collection of read-only file where users can search for their data on their own. Once this is done we will also release the files and their respective contents available here that are under HPC. Additionally we will provide a download script to create the same folder/database structure as well as instructions to how to regularly update the files as new versions of databases become available. 
 
 ## Genome Module
 
-While it is possible to use the ensembl api class to query genomic ranges and intervals for instances where you are interested in only one genome (and its annotatoins) for the whole project and you will need to make repeated queries it would be more performant (and nicer to ther people using the ensembl api) to generate a data structure that can represent genomic/proteomic information. 
+While it is possible to use the ensembl api class to query genomic ranges and intervals for instances where you are interested in only one genome (and its annotations) for the whole project and you will need to make repeated queries it would be more performant (and nicer to the people using the ensembl api) to generate a data structure that can represent genomic/proteomic information. 
 
-This is were the genom module comes into play. The genome.genome.Genome class takes a genome fasta file and a gtf fjile and creates a database of genomic regions. These regions can then be queried by genes, transcripts, exons, cdss, introns and utrs depending on the avalibility of these annotation types in the gtf file. You can also extract sequences from the genome fasta file for any arbitrary genome interval (see Ranges and GenomicRanges below) as well as providing (or generating) transcritome and proteome fasta files. 
+This is were the genome module comes into play. The genome.genome.Genome class takes a genome fasta file and a gtf file and creates a database of genomic regions. These regions can then be queried by genes, transcripts, exons, cdss, introns and utrs depending on the availability of these annotation types in the gtf file. You can also extract sequences from the genome fasta file for any arbitrary genome interval (see Ranges and GenomicRanges below) as well as providing (or generating) transcriptome and proteome fasta files. 
 
-The genome module also suspports saving these results to an arbitrary database, whether this is your knowledge base or any other kind of SQL databse (could even be in-memory sqlite). Each genome instance can be created and stored independently so if your analysis/project requires multiple genomes (or multiple annotations of the same fasta file, these are treated as different genomes). There is also support for that. 
+The genome module also supports saving these results to an arbitrary database, whether this is your knowledge base or any other kind of SQL database (could even be in-memory sqlite). Each genome instance can be created and stored independently so if your analysis/project requires multiple genomes (or multiple annotations of the same fasta file, these are treated as different genomes). There is also support for that. 
 
 Finally for your own work you can add arbitrary annotations to each of the tables in `JSON` format and then query them later. 
 
@@ -90,7 +90,7 @@ Finally for your own work you can add arbitrary annotations to each of the table
 
 This module is there to represent biological sequences. There are a few methods (more to come, please create an issue if you'd like to see specific things). 
 
-The base `Sequence` class can take 4 different kinds of sequences (DNA, RNA, protein and [3di](https://github.com/steineggerlab/foldseek)) and store arbitary properties and annoations in the features property. You can read/write these to fasta files, run blast searches using NCBI's blast api calculate msas using mmseqs (this will be moved to containers module and will call that container by default in the future) and calculate embeddings using several different AI models likek ESM2/3 or nucleotide transformer (more will come, please create an issue if you would like to see more models). 
+The base `Sequence` class can take 4 different kinds of sequences (DNA, RNA, protein and [3di](https://github.com/steineggerlab/foldseek)) and store arbitrary properties and annotations in the features property. You can read/write these to fasta files, run blast searches using NCBI's blast API calculate msas using mmseqs (this will be moved to containers module and will call that container by default in the future) and calculate embeddings using several different AI models like ESM2/3 or nucleotide transformer (more will come, please create an issue if you would like to see more models).
 
 For collections of sequences there are 2 other class types, `SequenceList` and `SequenceDict`, as the name suggests there are `list` and `dict`  like instances and contain many other methods that list and dictionaries have. Please see the sequence module readme for more information and usage instructions. 
 
@@ -98,33 +98,33 @@ For collections of sequences there are 2 other class types, `SequenceList` and `
 
 Similar to sequence module, the main goal is to store sequences and related information as well as some basic calculations related to biological structures. 
 
-The base `Structure` class can take a pbd file and load its structure. It can extract the sequence of the structure, calculate embeddings using ESM3, calculate solvent accesible surface area, get its 3Di sequence (see above), align it to another `Structure` instance and write to results to a pdb file. Still under construction, you can also predict a structure using one of (OmegaFold, Alphafold2, AlphaFold3-you need to get your own weights due to licensing requirements, Boltz1 and Boltz2). These will be calls to the `ContainerRunner` module and results will be saved to disk. 
+The base `Structure` class can take a pbd file and load its structure. It can extract the sequence of the structure, calculate embeddings using ESM3, calculate solvent accessible surface area, get its 3Di sequence (see above), align it to another `Structure` instance and write to results to a pdb file. Still under construction, you can also predict a structure using one of (OmegaFold, Alphafold2, AlphaFold3-you need to get your own weights due to licensing requirements, Boltz1 and Boltz2). These will be calls to the `ContainerRunner` module and results will be saved to disk. 
 
 There is also a `StructureComplex` instance and as the name suggests this is there to represent complexes. These can be multiple proteins, or a protein+ligand, DNA/RNA/Protein complexes. Similar to the `Structure` instance we are working on creating `ContainerRunner` calls to predict arbitrary structure complexes using AlphaFold2/3 and Boltz1/2. 
 
-Additionally we are working on creating a `Simulation` class to sample protein structure fluctiations either via [Openmm](https://openmm.org/) (very computationally intensive, but accurate and time resolved), [BioEmu](https://github.com/microsoft/bioemu) and [AlphaFlow](https://github.com/bjing2016/alphaflow). These again will be calls to `ContainerRunner` calls, which means if you have other calculations that will utilize these containers for arbitrary outputs. 
+Additionally we are working on creating a `Simulation` class to sample protein structure fluctuations either via [Openmm](https://openmm.org/) (very computationally intensive, but accurate and time resolved), [BioEmu](https://github.com/microsoft/bioemu) and [AlphaFlow](https://github.com/bjing2016/alphaflow). These again will be calls to `ContainerRunner` calls, which means if you have other calculations that will utilize these containers for arbitrary outputs. 
 
 ## Variant Module
 
-As the name suggests, this is module to representing variants. These can range from simple snps/indels to large structural variations and tandem repeat expansions. These variants take some basic required information for their representations. You can create genomic HGVS notations from these variatns which would make them compatible with some of the enpoints in ensembl module. If there are other vairtion types that we have missed please create an issue and describe how that variant is represented. Before doing so please look at the code in variant.variant file to get ian idea about how we are approaching this problem. 
+As the name suggests, this is module to representing variants. These can range from simple snps/indels to large structural variations and tandem repeat expansions. These variants take some basic required information for their representations. You can create genomic HGVS notations from these variants which would make them compatible with some of the endpoints in ensembl module. If there are other variation types that we have missed please create an issue and describe how that variant is represented. Before doing so please look at the code in variant.variant file to get an idea about how we are approaching this problem. 
 
 ## Ranges Module
 
-These module contains to main classes, `Ranges` moduel along with its counterparts `RangesList` and `RangesDict` are for storing arbitrary ranges. These can be any integer based ranges (that's the current limitation). Once you have a few ranges you can calculate the distance between them, you can merge them, calculate overlaps between 2 ranges. 
+These module contains to main classes, `Ranges` module along with its counterparts `RangesList` and `RangesDict` are for storing arbitrary ranges. These can be any integer based ranges (that's the current limitation). Once you have a few ranges you can calculate the distance between them, you can merge them, calculate overlaps between 2 ranges. 
 
-All these operations are also supported in `GenomicRanges` instances as well. It also requires strand and chromosome information for more biologically relevant calculations. These modules can be used on their own for perfoming pythonic operations similar to R's `GenomicFeatures` package. They are also being heavily used by the `genome.genome.Genome` class for querying, and some of the endpoints in the `apis.ensembl.Ensembl` instance. Please see the specific readme under the ranges module for usage instructions. 
+All these operations are also supported in `GenomicRanges` instances as well. It also requires strand and chromosome information for more biologically relevant calculations. These modules can be used on their own for perfuming pythonic operations similar to R's `GenomicFeatures` package. They are also being heavily used by the `genome.genome.Genome` class for querying, and some of the endpoints in the `apis.ensembl.Ensembl` instance. Please see the specific readme under the ranges module for usage instructions. 
 
 ## Knowledge Base
 
 This module is designed to store the results of your searches and queries in a database. The goal is to provide a way to store the data that you have retrieved from the different modules in a structured way that allows you to query it later. The database schema
-is still under heavy development. Currenlty we have schemas to store the paper classses, sequences, structures, variants and genomes. Due to semantic chunking and processing of the paper text there is a strict requiremen to use postgres as the database. This allows us
+is still under heavy development. Currently we have schemas to store the paper classes, sequences, structures, variants and genomes. Due to semantic chunking and processing of the paper text there is a strict requirement to use postgres as the database. This allows us
 to offload a lot of the semantic searching via pgvector extension. Unfortunately this means that you will need to install pgvector extension on your postgres database. We will be providing instructions how to do that under the knowledge base module readme.
 
-One of the most ambitions goals of this module it to provide a natural language search capabilities to many different data modalities that are represented in by othe other modules. This means that you will be able to search for papers, sequences, 
-structures, variants and genomes using natural language queries. The results will be returned in a structured way that allows you to easily access the data. This great flexilbilitly however comes at cost of requiring a gpu to run a language modeld that will 
-perform the queyring for you. We are currently working on a few different modeld that can be used for this purpose and will be providing a unified interface to use either your local models served via `llama.cpp` or `ollama` or remote models served via `huggingface.co` or
+One of the most ambitions goals of this module it to provide a natural language search capabilities to many different data modalities that are represented in by other modules. This means that you will be able to search for papers, sequences, 
+structures, variants and genomes using natural language queries. The results will be returned in a structured way that allows you to easily access the data. This great flexibility however comes at cost of requiring a GPU to run a language model that will 
+perform the querying for you. We are currently working on a few different models that can be used for this purpose and will be providing a unified interface to use either your local models served via `llama.cpp` or `ollama` or remote models served via `huggingface.co` or
 closed source models like `openai.com`. The goal of this project is not to provide an interface for analysis but rather to provide a way to store and query the data that you have retrieved from the different modules in a structured way that hopefully will 
-allow you to generate hypoteses to test and analyze. This means that we will **not** be providing any analysis pipelines or tools otherthan simple `ContainerRunner` calls to run your own pipelines and we will not be supporiting any kind of security or 
+allow you to generate hypotheses to test and analyze. This means that we will **not** be providing any analysis pipelines or tools other than simple `ContainerRunner` calls to run your own pipelines and we will not be supporting any kind of security or 
 will data privacy. This is a research project and we are not responsible for any data that you store in the knowledge base.
 
 ### Storing your searches/results
@@ -142,11 +142,11 @@ There are several avenues that we are currently exploring to expand the function
 + **Knowledge Base**: We are working on a knowledge base module that will allow you to store the results of your searches and queries in a database. 
 This will allow you to query the data later and generate hypotheses to test and analyze. The goal is to provide a way to store the data that you have retrieved from the different modules in a structured way that allows you to query it later.
 + **Container Library**: We are working on a library of containers that can be used to process your data. These will be available in our own docker container registry and can be used to create singularity/apptainer containers.
-+ **More APIs**: We are working on adding more APIs to the package. We are also trying to figure out a more streamlined way to combine the results of different api calls in to a more unified data structure. This would allow your 
++ **More APIs**: We are working on adding more APIs to the package. We are also trying to figure out a more streamlined way to combine the results of different API calls in to a more unified data structure. This would allow your 
 queries to be scripted more easily. 
 + **More Models**: We are working on adding more models to the package. We are hoping to integrate the state of the art models for sequence, structure and variant analyses. 
-+ **More Databases**: We are working on adding more databases to the package. We are then hoping to provide a way to query these databases in a unified way. These will be locally stored databases that do not require api calls.
-+ **More Documentation**: We are working on adding more documentation to the package. Once we have a more functional package we will create a deatailed documentation for each module and how they can be used together both interactively and in a pipeline.
++ **More Databases**: We are working on adding more databases to the package. We are then hoping to provide a way to query these databases in a unified way. These will be locally stored databases that do not require API calls.
++ **More Documentation**: We are working on adding more documentation to the package. Once we have a more functional package we will create a detailed documentation for each module and how they can be used together both interactively and in a pipeline.
 + **More Tests**: We are working on adding more tests to the package. This is an urgent requirement that we could use help with. If you have experience using `pytest` and would like to help us write tests please create a pull request. 
 + **More Examples**: We are working on adding more examples to the package. If you have suggestions for examples that you would like to see please create an issue on the GitHub repository and we will try to add them.
 + **More Containers**: We are working on adding more containers to the package. Once we have a series of containers that can be used to process your data will create instructions as to how to pull them and use them as either Docker or Singularity/Apptainer containers.
@@ -165,20 +165,11 @@ know if you find this package useful and if you have any suggestions for improve
 ### Issues
 
 If you find any bugs or have suggestions for improvements please create an issue on the GitHub repository. We will try to address them as soon as possible.
-Additionaly feel free to fork this repository and create a pull request with your changes. We are always looking for help with improving thie package and integrating as many 
-data sources and modalitites as possible.
+Additionally feel free to fork this repository and create a pull request with your changes. We are always looking for help with improving the package and integrating as many 
+data sources and modalities as possible.
 
 ### Contact us
 
-The best way to contact us is via github issues, you can create an issue about problems you are facing or features, datasets, containers you would like to have. 
+The best way to contact us is via GitHub issues, you can create an issue about problems you are facing or features, datasets, containers you would like to have. 
 If you have container/code pipeline etc. That you think others could use, you can create a module for it and create a pull request or make changes to one of the existing modules. 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) for how to do that and basic reccomendations about our (very relaxed) code standards. 
-
-
-
-
-
-
-
-
-
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for how to do that and basic recommendations about our (very relaxed) code standards. 

--- a/environment.yaml
+++ b/environment.yaml
@@ -9,5 +9,6 @@ dependencies:
   - postgresql=17.5
   - python=3.10
   - tesseract
+  - pip
   - pip:
       - torch==2.6.0


### PR DESCRIPTION
1. git clone by default creates `ccm_benchmate/` but installation suggested to  `cd benchmate/` (now `cd ccm_benchmate`)
2. environment.yaml file without independent `pip` entry leads to (harmless) warning: https://stackoverflow.com/questions/58544099/warning-after-i-run-the-command-conda-env-create-f-environment-yml
3. general typo fixes