### PR TITLE
Added information and scripts for container usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ build
 notebooks
 *demo
 docs/_site
-
+.venv/
+.dockerignore
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,50 @@
-FROM ubuntu:latest
-LABEL authors="alper"
+FROM mambaorg/micromamba:1.5.10
 
-ENTRYPOINT ["top", "-b"]
+USER root
+WORKDIR /opt/benchmate
+
+COPY environment.yaml /tmp/environment.yaml
+COPY requirements.txt /tmp/requirements.txt
+COPY . /opt/benchmate
+
+RUN micromamba install -y -n base -c conda-forge -c bioconda python=3.10 pip git && \
+    micromamba install -y -n base -f /tmp/environment.yaml && \
+    micromamba clean --all --yes
+
+# torch first
+RUN micromamba run -n base pip install --no-cache-dir torch==2.5.1 torchvision==0.20.1
+
+# install everything else (remove/comment flash_attn + detectron2 in requirements.txt)
+RUN micromamba run -n base pip install --no-cache-dir -r /tmp/requirements.txt
+
+# then the two torch-coupled packages
+RUN micromamba run -n base pip install --no-cache-dir --no-build-isolation flash_attn
+RUN micromamba run -n base pip install --no-cache-dir --no-build-isolation \
+    git+https://github.com/facebookresearch/detectron2.git@ff53992b1985b63bd3262b5a36167098e3dada02
+
+RUN micromamba run -n base pip install --no-cache-dir --no-deps --no-build-isolation /opt/benchmate
+
+RUN micromamba install -y -n base -c conda-forge -c bioconda \
+    python=3.10 \
+    pip \
+    git \
+    postgresql \
+    rdkit-postgresql \
+    compilers \
+    make \
+    cmake && \
+    micromamba clean --all --yes
+
+RUN micromamba run -n base bash -lc '\
+    git clone https://github.com/pgvector/pgvector.git /tmp/pgvector && \
+    cd /tmp/pgvector && \
+    make && \
+    make install && \
+    rm -rf /tmp/pgvector'
+
+ENV PATH=/opt/conda/bin:$PATH
+RUN echo 'export PATH=/opt/conda/bin:$PATH' >> /home/mambauser/.bashrc && \
+    echo 'export PATH=/opt/conda/bin:$PATH' >> /home/mambauser/.bash_profile
+USER mambauser
+
+CMD ["python", "-c", "import benchmate; print('benchmate container ready')"]

--- a/containerization/benchmate-run.sh
+++ b/containerization/benchmate-run.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Normalize the runtime environment inside the container so Postgres and
+# Benchmate use the conda-installed binaries
+export PATH="/opt/conda/bin:${PATH}"
+export LANG="${LANG:-C.UTF-8}"
+export LC_ALL="${LC_ALL:-C.UTF-8}"
+
+DB_PORT="${BM_DB_PORT:-5544}"
+DB_NAME="${BM_DB_NAME:-benchmate}"
+DB_DIR="${BM_DB_DIR:-/work/pgdata}"
+POSTGRES_LOG="${BM_POSTGRES_LOG:-${DB_DIR}/postgres.log}"
+
+log() {
+  printf '[benchmate-run] %s\n' "$*"
+}
+
+fail() {
+  printf '[benchmate-run] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+# A Postgres cluster created by initdb will always contain these
+is_valid_pgdata_dir() {
+  [[ -f "${DB_DIR}/PG_VERSION" && -d "${DB_DIR}/base" && -d "${DB_DIR}/global" ]]
+}
+
+
+dir_is_empty() {
+  [[ -z "$(find "${DB_DIR}" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]
+}
+
+# Postgres initialization is not allowed as root, so fail early 
+if [[ "$(id -u)" -eq 0 ]]; then
+  fail "PostgreSQL cannot be initialized as root. Run as a non-root user."
+fi
+
+# If the user did not provide a command, start an interactive shell after setup
+if [[ $# -eq 0 ]]; then
+  set -- bash
+fi
+
+log "Using PostgreSQL data directory: ${DB_DIR}"
+
+if [[ ! -e "${DB_DIR}" ]]; then
+  log "Database directory does not exist. Creating ${DB_DIR}"
+  mkdir -p "${DB_DIR}"
+fi
+
+if [[ ! -d "${DB_DIR}" ]]; then
+  fail "${DB_DIR} exists but cannot be used as a PostgreSQL data directory."
+fi
+
+# Postgres requires strict permissions on PGDATA, some filesystems will
+# refuse this change, so we warn if the final mode is still too permissive
+chmod 700 "${DB_DIR}" 2>/dev/null || true
+MODE="$(stat -c '%a' "${DB_DIR}" 2>/dev/null || true)"
+if [[ -n "${MODE}" && "${MODE}" != "700" && "${MODE}" != "750" ]]; then
+  log "Database directory mode is ${MODE}. PostgreSQL may reject this path unless the filesystem allows 700 or 750."
+fi
+
+if is_valid_pgdata_dir; then
+  log "Existing PostgreSQL cluster detected. Reusing it."
+elif dir_is_empty; then
+  log "No PostgreSQL cluster found. Initializing a new cluster."
+  initdb -D "${DB_DIR}"
+else
+  fail "Path ${DB_DIR} exists but is not a valid PostgreSQL data directory."
+fi
+
+if pg_ctl -D "${DB_DIR}" status >/dev/null 2>&1; then
+  log "PostgreSQL is already running for ${DB_DIR}"
+else
+  log "Starting PostgreSQL on port ${DB_PORT}"
+  pg_ctl -D "${DB_DIR}" -l "${POSTGRES_LOG}" -o "-p ${DB_PORT}" start
+fi
+
+log "Waiting for PostgreSQL to accept connections"
+until pg_isready -p "${DB_PORT}" >/dev/null 2>&1; do
+  sleep 1
+done
+
+if psql -p "${DB_PORT}" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" | grep -q 1; then
+  log "Database ${DB_NAME} already exists"
+else
+  log "Creating database ${DB_NAME}"
+  createdb -p "${DB_PORT}" "${DB_NAME}"
+fi
+
+log "Ensuring required PostgreSQL extensions are installed"
+psql -p "${DB_PORT}" -d "${DB_NAME}" -c "CREATE EXTENSION IF NOT EXISTS vector;" >/dev/null
+psql -p "${DB_PORT}" -d "${DB_NAME}" -c "CREATE EXTENSION IF NOT EXISTS rdkit;" >/dev/null
+
+# Export the database URL for easy access, and run any additional commands provided
+export DATABASE_URL="postgresql+psycopg2://localhost:${DB_PORT}/${DB_NAME}"
+log "DATABASE_URL set to ${DATABASE_URL}"
+log "Running command: $*"
+exec "$@"

--- a/containerization/benchmate.sh
+++ b/containerization/benchmate.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+RUNTIME="docker"
+IMAGE="ccm-benchmate:full"
+DB_DIR=""
+DB_NAME="benchmate"
+DB_PORT="5544"
+CONTAINER_DB_DIR="/work/pgdata"
+DOCKER_EXTRA_ARGS=()
+SINGULARITY_EXTRA_ARGS=()
+SHOW_COMMAND=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  containerization/benchmate.sh --db-dir /path/to/db [options] [-- command...]
+
+Options:
+  --runtime RUNTIME           docker or singularity (default: docker)
+  --db-dir PATH               Host path to the PostgreSQL data directory (required)
+  --container IMAGE_OR_SIF    Docker image name or Singularity .sif path
+  --db-name NAME              PostgreSQL database name to create/reuse (default: benchmate)
+  --db-port PORT              PostgreSQL port inside the container (default: 5544)
+  --container-db-dir PATH     Mount point inside the container (default: /work/pgdata)
+  --docker-arg ARG            Extra argument to pass to docker run (repeatable)
+  --singularity-arg ARG       Extra argument to pass to singularity exec (repeatable)
+  --bind SPEC                 Convenience alias that appends '--bind SPEC' to singularity exec
+  --show-command              Print the fully expanded runtime command before execution
+  -h, --help                  Show this message
+
+Examples:
+  containerization/benchmate.sh --runtime docker --db-dir /tmp/benchmate_pgtest -- bash
+  containerization/benchmate.sh --runtime singularity --container /path/to/image.sif --db-dir /path/to/db -- python myscript.py
+EOF
+}
+
+log() {
+  printf '[benchmate] %s\n' "$*"
+}
+
+fail() {
+  printf '[benchmate] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+# Make sure the provided database directory exists and can be used for PostgreSQL
+ensure_db_dir() {
+  [[ -n "${DB_DIR}" ]] || fail "--db-dir is required"
+
+  if [[ ! -e "${DB_DIR}" ]]; then
+    log "Creating database directory: ${DB_DIR}"
+    mkdir -p "${DB_DIR}"
+  fi
+
+  [[ -d "${DB_DIR}" ]] || fail "${DB_DIR} exists but is not a directory"
+
+  chmod 700 "${DB_DIR}" 2>/dev/null || true
+  local mode
+  mode="$(stat -c '%a' "${DB_DIR}" 2>/dev/null || true)"
+  if [[ -n "${mode}" && "${mode}" != "700" && "${mode}" != "750" ]]; then
+    fail "Database directory ${DB_DIR} has mode ${mode}. PostgreSQL requires 700 or 750 for PGDATA."
+  fi
+}
+
+# For Singulairty we need to define Linux users so that initdb can run
+# needs the current Linux user to be resolvable to a username
+build_passwd_file() {
+  local passwd_file="./benchmate.passwd"
+
+  {
+    printf 'root:x:0:0:root:/root:/bin/bash\n'
+    printf 'mambauser:x:57439:57439::/home/mambauser:/bin/bash\n'
+    printf '%s:x:%s:%s:%s:%s:/bin/bash\n' "$(id -un)" "$(id -u)" "$(id -g)" "$(id -un)" "${HOME}"
+  } > "${passwd_file}"
+
+  printf '%s' "${passwd_file}"
+}
+
+# Take a label plus a command, print the label, 
+# then print the command in a shell-safe way so the user can see or reuse it
+print_command() {
+  local label="$1"
+  shift
+  printf '[benchmate] %s:\n' "${label}"
+  printf '  '
+  printf '%q ' "$@"
+  printf '\n'
+}
+
+print_multiline_command() {
+  local label="$1"
+  local body="$2"
+  printf '[benchmate] %s:\n' "${label}"
+  printf '%s\n' "${body}"
+}
+
+# The raw command examples are runtime-specific: Docker needs startup logic
+# in a fresh container, while Singularity can have a simpler follow-up
+# access pattern once PostgreSQL is started.
+print_next_steps() {
+  local runtime_label="$1"
+  shift
+  log "Setup will be handled automatically each time you run this launcher with the same --db-dir."
+  if [[ "${runtime_label}" == "Docker" ]]; then
+    log "For Docker, a fresh container will need to start PostgreSQL before using the mounted database."
+    print_multiline_command "Example Docker user command" "$1"
+  else
+    log "Once PostgreSQL is running, you can access it with a command like this:"
+    print_multiline_command "Example ${runtime_label} access command" "$1"
+  fi
+}
+
+# Build the shell snippet shown to Docker users who want to start PostgreSQL
+# themselves instead of routing through benchmate-run.sh.
+build_standalone_inner_cmd() {
+  local quoted_user_cmd
+  quoted_user_cmd="$(printf '%q ' "$@")"
+
+  printf '%s' \
+"export PATH=/opt/conda/bin:\$PATH LANG=C.UTF-8 LC_ALL=C.UTF-8; \
+if ! pg_ctl -D ${CONTAINER_DB_DIR} status >/dev/null 2>&1; then \
+  pg_ctl -D ${CONTAINER_DB_DIR} -l ${CONTAINER_DB_DIR}/postgres.log -o '-p ${DB_PORT}' start; \
+fi; \
+until pg_isready -p ${DB_PORT} >/dev/null 2>&1; do sleep 1; done; \
+export DATABASE_URL=postgresql+psycopg2://localhost:${DB_PORT}/${DB_NAME}; \
+${quoted_user_cmd}"
+}
+
+# Each docker run starts a fresh container with no PostgreSQL 
+# server already running, so a full startup is needed.
+build_docker_show_cmd() {
+  local inner_cmd
+  inner_cmd="$(build_standalone_inner_cmd bash)"
+
+  printf -v DOCKER_SHOW_CMD '%s\n' \
+    "docker run --rm -it --platform linux/amd64 \\" \
+    "  -v ${DB_DIR}:${CONTAINER_DB_DIR} \\" \
+    "  ${IMAGE} \\" \
+    "  bash -lc \"${inner_cmd}\""
+}
+
+# Singularity reuse the same already-running PostgreSQL server, so
+# the example here just shows how to re-enter the container context and connect.
+build_singularity_show_cmd() {
+  local passwd_file="$1"
+  shift
+
+  printf -v SINGULARITY_SHOW_CMD '%s\n' \
+    "singularity exec \\" \
+    "  --bind ${DB_DIR}:${CONTAINER_DB_DIR} \\" \
+    "  --bind ${passwd_file}:/etc/passwd \\" \
+    "  ${IMAGE} \\" \
+    "  bash -lc 'export PATH=/opt/conda/bin:\$PATH LANG=C.UTF-8 LC_ALL=C.UTF-8; /opt/conda/bin/psql -p ${DB_PORT} -d ${DB_NAME}'"
+}
+
+run_docker() {
+  # The normal Docker path always routes through benchmate-run.sh so setup,
+  # reuse, and environment export happen automatically for each invocation.
+  local cmd=(
+    docker run --rm
+    -it
+    --platform linux/amd64
+    -v "${DB_DIR}:${CONTAINER_DB_DIR}"
+    -e "BM_DB_DIR=${CONTAINER_DB_DIR}"
+    -e "BM_DB_NAME=${DB_NAME}"
+    -e "BM_DB_PORT=${DB_PORT}"
+  )
+
+  if [[ ${#DOCKER_EXTRA_ARGS[@]} -gt 0 ]]; then
+    cmd+=("${DOCKER_EXTRA_ARGS[@]}")
+  fi
+
+  cmd+=(
+    "${IMAGE}"
+    /opt/benchmate/containerization/benchmate-run.sh
+    "$@"
+  )
+
+  log "Launching Docker image ${IMAGE}"
+  log "Mounting ${DB_DIR} at ${CONTAINER_DB_DIR}"
+  log "Using database name ${DB_NAME} on port ${DB_PORT}"
+  if [[ "${SHOW_COMMAND}" -eq 1 ]]; then
+    local DOCKER_SHOW_CMD=""
+    build_docker_show_cmd "$@"
+    print_next_steps "Docker" "${DOCKER_SHOW_CMD}"
+  else
+    log "Use this launcher again with the same --db-dir to reuse the database on future runs."
+  fi
+
+  exec "${cmd[@]}"
+}
+
+run_singularity() {
+  local passwd_file
+  passwd_file="$(build_passwd_file)"
+
+  # Singularity runs as the invoking HPC user, so we inject a passwd entry and
+  # then hand off to the same in-container script used by Docker.
+  local inner_cmd
+  inner_cmd="export LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/opt/conda/bin:\$PATH BM_DB_DIR='${CONTAINER_DB_DIR}' BM_DB_NAME='${DB_NAME}' BM_DB_PORT='${DB_PORT}'; /opt/benchmate/containerization/benchmate-run.sh $(printf '%q ' "$@")"
+
+  local cmd=(
+    singularity exec
+    --bind "${DB_DIR}:${CONTAINER_DB_DIR}"
+    --bind "${passwd_file}:/etc/passwd"
+  )
+
+  if [[ ${#SINGULARITY_EXTRA_ARGS[@]} -gt 0 ]]; then
+    cmd+=("${SINGULARITY_EXTRA_ARGS[@]}")
+  fi
+
+  cmd+=(
+    "${IMAGE}"
+    bash -lc "${inner_cmd}"
+  )
+
+  log "Launching Singularity image ${IMAGE}"
+  log "Binding ${DB_DIR} at ${CONTAINER_DB_DIR}"
+  log "Injecting passwd entry for $(id -un) so PostgreSQL can initialize as the invoking user"
+  log "Using passwd file ${passwd_file}"
+  log "Using database name ${DB_NAME} on port ${DB_PORT}"
+  if [[ "${SHOW_COMMAND}" -eq 1 ]]; then
+    local SINGULARITY_SHOW_CMD=""
+    build_singularity_show_cmd "${passwd_file}" "$@"
+    print_next_steps "Singularity" "${SINGULARITY_SHOW_CMD}"
+  else
+    log "Use this launcher again with the same --db-dir to reuse the database on future runs."
+  fi
+
+  exec "${cmd[@]}"
+}
+
+# Parse the command line options, recognize the known flags and store values in variables
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --runtime)
+      RUNTIME="${2:-}"
+      shift 2
+      ;;
+    --db-dir)
+      DB_DIR="${2:-}"
+      shift 2
+      ;;
+    --container|--image)
+      IMAGE="${2:-}"
+      shift 2
+      ;;
+    --db-name)
+      DB_NAME="${2:-}"
+      shift 2
+      ;;
+    --db-port)
+      DB_PORT="${2:-}"
+      shift 2
+      ;;
+    --container-db-dir)
+      CONTAINER_DB_DIR="${2:-}"
+      shift 2
+      ;;
+    --docker-arg)
+      DOCKER_EXTRA_ARGS+=("${2:-}")
+      shift 2
+      ;;
+    --singularity-arg)
+      SINGULARITY_EXTRA_ARGS+=("${2:-}")
+      shift 2
+      ;;
+    --bind)
+      SINGULARITY_EXTRA_ARGS+=(--bind "${2:-}")
+      shift 2
+      ;;
+    --show-command)
+      SHOW_COMMAND=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+ensure_db_dir
+
+if [[ $# -eq 0 ]]; then
+  set -- bash
+fi
+
+case "${RUNTIME}" in
+  docker)
+    run_docker "$@"
+    ;;
+  singularity)
+    [[ -f "${IMAGE}" ]] || fail "Singularity container not found: ${IMAGE}"
+    run_singularity "$@"
+    ;;
+  *)
+    fail "Unsupported runtime: ${RUNTIME}. Use docker or singularity."
+    ;;
+esac

--- a/docs/containerization/CONTAINER_USAGE.md
+++ b/docs/containerization/CONTAINER_USAGE.md
@@ -1,0 +1,226 @@
+# Benchmate Container Usage
+
+This document explains how to use the Benchmate launcher script for Docker and Singularity / Apptainer.
+
+## Get The Launcher Script
+
+While you do not install specifc packages and dependencies, you do need the launcher script.
+
+Download it and make it executable:
+
+```bash
+curl -L -o benchmate.sh https://github.com/ccmbioinfo/ccm_benchmate/blob/master/containerization/benchmate.sh
+chmod +x benchmate.sh
+```
+
+The launcher is the normal entrypoint. It handles PostgreSQL setup automatically, reuses the same database directory across runs, and passes your command into the container.
+
+## Docker
+
+### Install
+
+Install Docker Desktop or another Docker runtime that supports Linux containers.
+
+You will also need the Benchmate image locally, for example:
+
+```bash
+docker pull rohanahkhan/ccm-benchmate:full
+```
+
+If your local image tag is different, pass it with `--container`.
+
+### Where `PGDATA` Should Live
+
+For Docker, choose a host directory that will hold the PostgreSQL data files and reuse the same path across runs.
+
+Example:
+
+```bash
+mkdir -p /tmp/benchmate_pgtest
+chmod 700 /tmp/benchmate_pgtest
+```
+
+The launcher mounts that host directory into the container at `/work/pgdata` by default.
+
+### Recommended First Run
+
+The recommended first run is an interactive shell:
+
+```bash
+./benchmate.sh --runtime docker --container rohanahkhan/ccm-benchmate:full --db-dir /tmp/benchmate_pgtest -- bash
+```
+
+What happens on the first run:
+
+- the database directory is created if needed
+- PostgreSQL is initialized if the directory is empty
+- PostgreSQL starts
+- the database is created if needed
+- the `vector` and `rdkit` extensions are ensured
+- `DATABASE_URL` is exported
+
+On later runs, reuse the same `--db-dir`.
+
+### Quick Docker Checks
+
+Inside the shell, useful checks are:
+
+```bash
+echo "$DATABASE_URL"
+psql -p 5544 -d benchmate -c '\dx'
+psql -p 5544 -d benchmate -c "SELECT '[1,2,3]'::vector;"
+psql -p 5544 -d benchmate -c "SELECT mol_to_smiles('c1ccccc1'::mol);"
+```
+
+A one-shot command also works:
+
+```bash
+./benchmate.sh --runtime docker --container rohanahkhan/ccm-benchmate:full --db-dir /tmp/benchmate_pgtest -- python -c "import os; print(os.environ['DATABASE_URL'])"
+```
+
+## Singularity / Apptainer
+
+### Install And HPC Setup
+
+Start an interactive allocation first, then load Singularity:
+
+```bash
+srun --cpus-per-task 4 --mem 8G --time 24:00:00 --constraint=AlmaLinux8 --pty bash
+module load Singularity
+```
+
+If you want to build a local `.sif` from Docker Hub, set cache and temp directories first:
+
+```bash
+export SINGULARITY_CACHEDIR=/path/to/singularity_cache
+export SINGULARITY_TMPDIR=/path/to/singularity_tmp
+mkdir -p "$SINGULARITY_CACHEDIR" "$SINGULARITY_TMPDIR"
+```
+
+Then pull the image (this will take awhile):
+
+```bash
+singularity pull /hpf/largeprojects/ccmbio/students/rkhan/benchmate_package/mar19/ccm-benchmate_full.sif docker://rohanahkhan/ccm-benchmate:full
+```
+
+### Where `PGDATA` Should Live
+
+For Singularity / Apptainer, choose a writable path on a filesystem that PostgreSQL accepts. The directory must allow final permissions of `700` or `750`.
+
+Reuse the same `--db-dir` across runs.
+
+### Passwd File And Runtime Notes
+
+The launcher creates a reusable `./benchmate.passwd` file in the current working directory and binds it to `/etc/passwd`.
+
+This is needed because Singularity runs as the invoking HPC UID, and `initdb` requires that Linux user to be resolvable inside the container.
+
+The launcher also normalizes locale to `C.UTF-8`.
+
+### Recommended First Run
+
+The recommended first run is an interactive shell:
+
+```bash
+./benchmate.sh \
+  --runtime singularity \
+  --container /hpf/largeprojects/ccmbio/students/rkhan/benchmate_package/mar19/ccm-benchmate_full.sif \
+  --db-dir /hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/DRAGEN_genes/test/test \
+  -- bash
+```
+
+Inside the shell, useful checks are:
+
+```bash
+echo "$DATABASE_URL"
+psql -p 5544 -d benchmate -c '\dx'
+psql -p 5544 -d benchmate -c "SELECT '[1,2,3]'::vector;"
+psql -p 5544 -d benchmate -c "SELECT mol_to_smiles('c1ccccc1'::mol);"
+```
+
+A one-shot command also works:
+
+```bash
+./benchmate.sh \
+  --runtime singularity \
+  --container /hpf/largeprojects/ccmbio/students/rkhan/benchmate_package/mar19/ccm-benchmate_full.sif \
+  --db-dir /hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/DRAGEN_genes/test/test \
+  -- python -c "import os; print(os.environ['DATABASE_URL'])"
+```
+
+## Shared Extras
+
+### `--show-command`
+
+Use `--show-command` when you want the launcher to print a raw runtime example of how to run the container without the launcher script. For most use cases the launcher script will get the job done, but if you need a specific invocation that can be used to launch the containers with the database, use this command.
+
+Docker example:
+
+```bash
+./benchmate.sh --runtime docker --db-dir /tmp/benchmate_pgtest --show-command -- bash
+```
+
+Singularity example:
+
+```bash
+./benchmate.sh --runtime singularity --container /path/to/image.sif --db-dir /path/to/pgdata --show-command -- bash
+```
+
+What it means:
+
+- for Docker, the printed command includes PostgreSQL startup logic because each `docker run` starts a fresh container
+- for Singularity, the printed command is a follow-up access pattern for cases where PostgreSQL is already running
+
+### Extra Runtime Args
+
+Pass extra runtime flags through the launcher when needed.
+
+Docker examples:
+
+```bash
+./benchmate.sh --runtime docker --db-dir /tmp/benchmate_pgtest --docker-arg "--gpus" --docker-arg "all" -- bash
+```
+
+```bash
+./benchmate.sh --runtime docker --db-dir /tmp/benchmate_pgtest --docker-arg "-p" --docker-arg "5544:5544" -- bash
+```
+
+Singularity examples:
+
+```bash
+./benchmate.sh --runtime singularity --container /path/to/image.sif --db-dir /path/to/pgdata --singularity-arg "--nv" -- bash
+```
+
+```bash
+./benchmate.sh --runtime singularity --container /path/to/image.sif --db-dir /path/to/pgdata --bind /some/extra/path:/extra/path -- bash
+```
+
+### Passing Your Own Command
+
+Everything after `--` is passed into the container.
+
+Examples:
+
+```bash
+./benchmate.sh --runtime docker --db-dir /tmp/benchmate_pgtest -- python myscript.py
+```
+
+```bash
+./benchmate.sh --runtime singularity --container /path/to/image.sif --db-dir /path/to/pgdata -- psql -p 5544 -d benchmate -c "SELECT current_database();"
+```
+
+```bash
+./benchmate.sh --runtime docker --db-dir /tmp/benchmate_pgtest -- python -c "import os; print(os.environ['DATABASE_URL'])"
+```
+
+### Suggested Quick Tests
+
+After the first successful launcher run, these are good checks:
+
+```bash
+psql -p 5544 -d benchmate -c '\dx'
+psql -p 5544 -d benchmate -c "SELECT '[1,2,3]'::vector;"
+psql -p 5544 -d benchmate -c "SELECT mol_to_smiles('c1ccccc1'::mol);"
+```
+
+If you want to confirm the database directory is reused, run the launcher a second time with the same `--db-dir`.

--- a/docs/containerization/DOCKER_IMAGE.md
+++ b/docs/containerization/DOCKER_IMAGE.md
@@ -1,0 +1,113 @@
+# Benchmate Docker Image
+
+This document covers how to build the Benchmate container image locally, run a few smoke tests, and optionally push the image to Docker Hub.
+
+## 1. Build
+
+From the repo root:
+
+```bash
+docker buildx build --no-cache --platform linux/amd64 -t ccm-benchmate:full --load .
+```
+
+`--platform linux/amd64` is recommended when building on macOS and for later Singularity/Apptainer use.
+
+## 2. Quick Binary Check
+
+Confirm that the expected PostgreSQL and Python executables are on `PATH`:
+
+```bash
+docker run --rm --platform linux/amd64 --entrypoint /bin/bash ccm-benchmate:full -lc 'echo $PATH; command -v python; command -v postgres; command -v initdb; command -v pg_ctl; command -v psql'
+```
+
+## 3. Smoke Tests
+
+Use a fresh test data directory:
+
+```bash
+rm -rf /tmp/benchmate_pgtest
+mkdir -p /tmp/benchmate_pgtest
+chmod 700 /tmp/benchmate_pgtest
+```
+
+Interactive test:
+
+```bash
+docker run --rm -it \
+  --platform linux/amd64 \
+  -v /tmp/benchmate_pgtest:/work/pgdata \
+  --entrypoint /bin/bash \
+  ccm-benchmate:full \
+  -lc 'pg_ctl -D /work/pgdata -l /work/pgdata/postgres.log -o "-p 5544" start && python'
+```
+
+Knowledge base schema test:
+
+```bash
+docker run --rm \
+  --platform linux/amd64 \
+  -v /tmp/benchmate_pgtest:/work/pgdata \
+  --entrypoint /bin/bash \
+  ccm-benchmate:full \
+  -lc '/opt/conda/bin/python - <<'"'"'PY'"'"'
+from sqlalchemy import create_engine, inspect
+from benchmate.knowledge_base.knowledge_base import KnowledgeBase
+
+engine = create_engine("postgresql+psycopg2://localhost:5544/benchmate_demo")
+kb = KnowledgeBase(engine)
+kb._create_kb()
+print(inspect(engine).get_table_names())
+PY'
+```
+
+`pgvector` test:
+
+```bash
+docker run --rm \
+  --platform linux/amd64 \
+  -v /tmp/benchmate_pgtest:/work/pgdata \
+  --entrypoint /bin/bash \
+  ccm-benchmate:full \
+  -lc '/opt/conda/bin/psql -p 5544 -d benchmate_demo -c "CREATE TABLE IF NOT EXISTS items (id serial primary key, embedding vector(3)); INSERT INTO items (embedding) VALUES (\$\$[1,2,3]\$\$), (\$\$[2,3,4]\$\$); SELECT * FROM items ORDER BY embedding <-> \$\$[1,1,1]\$\$ LIMIT 2;"'
+```
+
+RDKit test:
+
+```bash
+docker run --rm \
+  --platform linux/amd64 \
+  -v /tmp/benchmate_pgtest:/work/pgdata \
+  --entrypoint /bin/bash \
+  ccm-benchmate:full \
+  -lc '/opt/conda/bin/psql -p 5544 -d benchmate_demo -c "SELECT mol_to_smiles(\$\$c1ccccc1\$\$::mol);"'
+```
+
+## 4. Launcher Test
+
+Once the image is built, test the user-facing launcher:
+
+```bash
+containerization/benchmate.sh --runtime docker --container ccm-benchmate:full --db-dir /tmp/benchmate_pgtest_launcher -- bash
+```
+
+## 5. Push To Docker Hub
+
+Log in first:
+
+```bash
+docker login
+```
+
+Tag the image:
+
+```bash
+docker tag ccm-benchmate:full rohanahkhan/ccm-benchmate:full
+```
+
+Push:
+
+```bash
+docker push rohanahkhan/ccm-benchmate:full
+```
+
+Adjust the repository or tag names to match the release you want to publish.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,49 +10,48 @@ readme = "README.md"
 requires-python = ">=3.10"
 keywords = ["bioinformatics", "LLM", "transformers", "molecular", "structure", "RAG"]
 
-[project.urls]
-Homepage = "https://ccmbioinfo.github.io/ccm_benchmate/"
-Repository = "https://github.com/ccmbioinfo/ccm_benchmate"
-
-[project.dependencies]
-pandas = "==2.1.4"
-biopython = "*"
-beautifulsoup4 = "*"
-transformers = "*"
-sentence-transformers = "*"
-qwen_vl_utils = "*"
-accelerate = "*"
-datasets = "*"
-requests = "*"
-biotite = "*"
-pymupdf4llm = "*"
-pymupdf = "*"
-layoutparser = "*"
-SQLAlchemy = "==1.4.54"
-chonkie[all] = "*"
-pysam = "*"
-lxml = "*"
-pgvector = "*"
-adapters = "*"
-colpali-engine = ">=0.3.0"
-docker = "*"
-openpyxl = "*"
-model2vec = "*"
-psycopg2 = "*"
-pytesseract = "*"
-rdkit = "*"
-flash_attn = "*"
-bitsandbytes = "*"
-
-# Git-based dependencies
-detectron2 = {url = "https://github.com/facebookresearch/detectron2.git", rev = "ff53992b1985b63bd3262b5a36167098e3dada02"}
-usearch-molecules = {url = "https://github.com/celalp/usearch-molecules.git"}
+dependencies = [
+  "pandas==2.1.4",
+  "biopython",
+  "beautifulsoup4",
+  "transformers",
+  "sentence-transformers",
+  "qwen_vl_utils",
+  "accelerate",
+  "datasets",
+  "requests",
+  "biotite",
+  "pymupdf4llm",
+  "pymupdf",
+  "layoutparser",
+  "SQLAlchemy==1.4.54",
+  "chonkie[all]",
+  "pysam",
+  "lxml",
+  "pgvector",
+  "adapters",
+  "colpali-engine>=0.3.0",
+  "docker",
+  "openpyxl",
+  "model2vec",
+  "psycopg2",
+  "pytesseract",
+  "rdkit",
+  "flash_attn",
+  "bitsandbytes",
+  "detectron2 @ git+https://github.com/facebookresearch/detectron2.git@ff53992b1985b63bd3262b5a36167098e3dada02",
+  "usearch-molecules @ git+https://github.com/celalp/usearch-molecules.git"
+]
 
 [project.optional-dependencies]
 dev = [
   "pytest",
   "pytest-cov"
 ]
+
+[project.urls]
+Homepage = "https://ccmbioinfo.github.io/ccm_benchmate/"
+Repository = "https://github.com/ccmbioinfo/ccm_benchmate"
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pymupdf4llm
 pymupdf
 layoutparser
 SQLAlchemy==1.4.54
-git+https://github.com/facebookresearch/detectron2.git@ff53992b1985b63bd3262b5a36167098e3dada02
+# git+https://github.com/facebookresearch/detectron2.git@ff53992b1985b63bd3262b5a36167098e3dada02
 git+https://github.com/celalp/usearch-molecules.git
 chonkie[all]
 pysam
@@ -24,10 +24,10 @@ pytest
 docker
 openpyxl
 model2vec
-psycopg2
+psycopg2-binary
 pytesseract
 rdkit
 pytest
 pytest-cov
-flash_attn
+# flash_attn
 bitsandbytes

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     package_data={"": ["*.json"]},
-    scripts=["benchmate/scripts/run_mmseqs.sh"],
+    # scripts=["benchmate/scripts/run_mmseqs.sh"],
     include_package_data=True
 )


### PR DESCRIPTION
A complete docker container based on the Dockerfile is available at docker://rohanahkhan/ccm-benchmate:full

Added a user-facing Benchmate container launcher for both Docker and Singularity/Apptainer, along with supporting container build and usage documentation.

The launcher:
- accepts Docker or Singularity as the runtime
- creates or reuses a persistent PostgreSQL data directory
- initializes PostgreSQL automatically when needed
- starts PostgreSQL and ensures the target database exists
- ensures the `vector` and `rdkit` PostgreSQL extensions are installed
- exports `DATABASE_URL`
- runs the user command after setup
- supports `--show-command` for raw runtime examples

The Singularity path includes the HPC-specific handling :
- runs as the invoking HPC UID
- creates a reusable `benchmate.passwd` file and binds it to `/etc/passwd`
- normalizes locale to `C.UTF-8`
- reuses a mounted persistent DB directory when the filesystem supports PostgreSQL permission requirements