### PR TITLE
Moving Paper class and adding natural language search

### DIFF
--- a/benchmate/config.yaml
+++ b/benchmate/config.yaml
@@ -8,7 +8,7 @@ project:
   project descriptions."
 
 knowledge_base:
-  conn_string: #this is the connection string to the database, it must be a postgres database connection
+  conn_string: postgresql+psycopg2://localhost:5544/benchmate # What you mean by this for paperinfo?  - But this still needs proper validation/testing in the rework branch once the rest of the startup path is stable. when using the container launcher, we can use the following if deafult values: postgresql+psycopg2://localhost:5544/benchmate
 
 literature:
   table_prompt: "You are an expert biologist who is responsible for reading and interpreting scientific tables. For a given table from a scientific paper interpret the table. 
@@ -37,15 +37,17 @@ inference:
     generation_kwargs: {} # other generation kwargs that you want to pass in, this is passed to model.generate
     quantization_kwargs: {} # if you want to use bitsandbytes quantization you can pass it here
 
-  text_embedding: #this is the model that is used to embed the text
+  text_embed: #this is the model that is used to embed the text
     cache_dir: benchmate/models/hf_models
-    model: Qwen/Qwen3-Embedding-0.6B
+    model_name: Qwen/Qwen3-Embedding-0.6B
     dimensions: 1024
     kwargs: {}
 
   text_rerank:
     cache_dir: benchmate/models/hf_models
-    model: Qwen/Qwen3-Rerank-0.6B
+    model_name: Qwen/Qwen3-Rerank-0.6B
+    model_kwargs: {}
+    tokenizer_kwargs: {}
     prefix: "<|im_start|>system\n
             Judge whether the Document meets the requirements based on the Query and the Instruct provided. 
             Note that the answer can only be \"yes\" or \"no\".<|im_end|>\n
@@ -56,7 +58,9 @@ inference:
 
   image_embed:
     cache_dir: benchmate/models/hf_models
-    model: microsoft/BiomedCLIP-PubMedBERT_256-vit_base_patch16_224
+    model_name: microsoft/BiomedCLIP-PubMedBERT_256-vit_base_patch16_224
+    model_kwargs: {}
+    processor_kwargs: {}
     processor_class: transformers.CLIPProcessor
     model_class: transformers.CLIPModel
     dimensions: 512
@@ -64,16 +68,17 @@ inference:
 
   image_rerank:
     cache_dir: benchmate/models/hf_models
-    model: vidore/colpali-v1.3
+    model_name: vidore/colpali-v1.3
+    model_kwargs: {}
+    processor_kwargs: {}
     model_class: transformers.ColPaliForRetrieval
     processor_class: transformers.ColPaliProcessor
 
   semantic_chunk:
-    model: benchmate/models/m2v_model
+    chunking_model: benchmate/models/m2v_model
     chunking_kwargs:
-      min_chunk_size: 100
+      chunk_size: 100
       min_sentences: 1
-      return_type: texts
       threshold: 0.75
 
 #these are binary locations if needed, you can leave just as the callable if they are in your $PATH

--- a/benchmate/inference/inference.py
+++ b/benchmate/inference/inference.py
@@ -3,6 +3,15 @@ import importlib
 import torch
 from benchmate.inference.utils import (TextRerank, TextEmbed, ImageRerank, ImageEmbed, SemanticChunk, InterpretImage)
 
+def resolve_dotted_object(path):
+    """
+    Resolve a dotted import path like `transformers.CLIPModel` into the
+    actual Python object.
+    """
+    module_name, attr_name = path.rsplit(".", 1)
+    module = importlib.import_module(module_name)
+    return getattr(module, attr_name)
+
 class Inference:
     def __init__(self, config):
         self.config = config
@@ -22,32 +31,32 @@ class Inference:
                                       self.config["image_embed"]["model_name"],
                                       self.config["image_embed"]["model_kwargs"],
                                       self.config["image_embed"]["processor_kwargs"],
-                                      importlib.import_module(self.config["image_embed"]["model_class"]),
-                                      importlib.import_module(self.config["image_embed"]["processor_class"]),
+                                      resolve_dotted_object(self.config["image_embed"]["model_class"]),
+                                      resolve_dotted_object(self.config["image_embed"]["processor_class"]),
                                       device=self.device,)
 
         self.image_rerank = ImageRerank(self.config["image_rerank"]["cache_dir"],
                                         self.config["image_rerank"]["model_name"],
                                         self.config["image_rerank"]["model_kwargs"],
                                         self.config["image_rerank"]["processor_kwargs"],
-                                        importlib.import_module(self.config["image_rerank"]["model_class"]),
-                                        importlib.import_module(self.config["image_rerank"]["processor_class"]),
+                                        resolve_dotted_object(self.config["image_rerank"]["model_class"]),
+                                        resolve_dotted_object(self.config["image_rerank"]["processor_class"]),
                                         device=self.device,)
 
-        self.semantic_chunk = SemanticChunk(self.config["semantic_chunk"]["chunking_model"],
-                                            **self.config["semantic_chunk"]["chunking_kwargs"],)
+        #self.semantic_chunk = SemanticChunk(self.config["semantic_chunk"]["chunking_model"],
+         #                                   **self.config["semantic_chunk"]["chunking_kwargs"],)
 
-        self.interpret_image = InterpretImage(self.config["interpret_image"]["cache_dir"],
-                                              self.config["interpret_image"]["model_name"],
-                                              self.config["interpret_image"]["model_kwargs"],
-                                              self.config["interpret_image"]["processor_kwargs"],
-                                              importlib.import_module(self.config["interpret_image"]["model_class"]),
-                                              importlib.import_module(self.config["interpret_image"]["processor_class"]),
-                                              device=self.device )
+#        self.interpret_image = InterpretImage(self.config["interpret_image"]["cache_dir"],
+#                                              self.config["interpret_image"]["model_name"],
+#                                              self.config["interpret_image"]["model_kwargs"],
+#                                              self.config["interpret_image"]["processor_kwargs"],
+#                                              resolve_dotted_object(self.config["interpret_image"]["model_class"]),
+#                                              resolve_dotted_object(self.config["interpret_image"]["processor_class"]),
+#                                              device=self.device )
 
     #TODO need to check if this is immediately compatible with the db
     def embed_text(self, texts):
-        embeddings=self.text_embed(texts)
+        embeddings = self.text_embed.encode(texts)
         return embeddings
 
     def embed_image(self, images):
@@ -65,10 +74,10 @@ class Inference:
         return [(score, image) for score, image in sorted(zip(scores, images), reverse=True)]
 
     def chunk_text(self, text):
-        return self.semantic_chunk.chunk_text(text)
+        raise NotImplementedError("Semantic chunking is temporarily disabled in this environment")
 
     def interpret_image(self, images):
-        return self.interpret_image.interpret(images)
+        raise NotImplementedError("Image interpretation is temporarily disabled in this environment")
 
     def text_score(self, query, texts):
         query_chunks = self.chunk_text(query)

--- a/benchmate/inference/utils.py
+++ b/benchmate/inference/utils.py
@@ -16,7 +16,9 @@ from qwen_vl_utils import process_vision_info
 #TODO this is vram cleanup
 class CleanupMixin:
     def cleanup_cuda(self):
-        """Fully clears GPU memory."""
+        """Fully clears GPU memory when CUDA is available."""
+        if not torch.cuda.is_available():
+            return
         torch.cuda.empty_cache()
         torch.cuda.ipc_collect()
         torch.cuda.synchronize()

--- a/benchmate/literature/literature.py
+++ b/benchmate/literature/literature.py
@@ -1,6 +1,8 @@
 import os.path
 import time
 import tempfile
+import requests
+
 
 from bs4 import BeautifulSoup as bs
 
@@ -196,6 +198,7 @@ class Paper:
         search openalex for the paper info and download link
         :return: fill in the paper info openalex_info and download_link
         """
+        download_link = None
         if self.info.pmc_id is not None:
             response = requests.get("https://www.ncbi.nlm.nih.gov/pmc/utils/oa/oa.fcgi?id={}".format(self.info.pmc_id))
             response.raise_for_status()

--- a/benchmate/literature/paperinfo.py
+++ b/benchmate/literature/paperinfo.py
@@ -46,114 +46,248 @@ class PaperInfo:
         papers_table = project.kb.db_tables["papers"]
         figures_table = project.kb.db_tables["figures"]
         tables_table = project.kb.db_tables["tables"]
-        body_text_table = project.kb.db_tables["body_text"]
         chunked_text_table = project.kb.db_tables["body_text_chunked"]
         references_table = project.kb.db_tables["references"]
         related_works_table = project.kb.db_tables["related_works"]
         cited_by_table = project.kb.db_tables["cited_by"]
 
-        stms = insert(papers_table.c.source_id, papers_table.c.source, papers_table.c.title,
-                      papers_table.c.project_id,
-                      papers_table.c.abstract, papers_table.c.abstract_embeddings,
-                      papers_table.c.pdf_url, papers_table.c.pdf_path,
-                      papers_table.c.openalex_response,
-                      papers_table.c.authors).values(self.id, self.id_type,
-                                                         self.title,
-                                                         project.project_id,
-                                                         self.abstract,
-                                                         self.abstract_embeddings,
-                                                         self.download_link,
-                                                         self.file_path,
-                                                         self.openalex_info,
-                                                         self.authors).returning(papers_table.c.paper_id)
-        
-        paper_id = project.kb.session().execute(stms).scalars().one()
+        # if abstract_embeddings is a NumPy array, it should be converted before insert
+        abstract_embedding = self.abstract_embeddings
+        if hasattr(abstract_embedding, "tolist"):
+            abstract_embedding = abstract_embedding.tolist()
 
+        # Unlike the older PaperInfo version, the current schema uses
+        # papers.id as the primary key and source, source_id as the 
+        # external identity, so we look up an existing row before inserting.
+        existing_stmts = select(papers_table.c.id).where(
+            papers_table.c.source == self.id_type,
+            papers_table.c.source_id == self.id,
+        )
+        paper_id = project.kb.session.execute(existing_stmts).scalar()
+
+        if paper_id is None:
+            stms = (
+                insert(papers_table)
+                .values(
+                    source_id=self.id,
+                    source=self.id_type,
+                    title=self.title,
+                    project_id=project.project_id,
+                    abstract=self.abstract,
+                    abstract_embeddings=abstract_embedding,
+                    pdf_url=self.download_link,
+                    pdf_path=self.file_path,
+                    openalex_response=self.openalex_info,
+                    authors=self.authors,
+                    full_text=self.text or "",
+                )
+                .returning(papers_table.c.id)
+            )
+
+            paper_id = project.kb.session.execute(stms).scalar_one()
+
+        # The older implementation assumed `self.figures[i]` was always a file path and
+        # inserted directly using older schema field names. In the current pipeline,
+        # figures may already be loaded as images, so this `if isinstance(...)`
+        # branch keeps both cases working. The nested checks also
+        # guard optional interpretation/embedding fields so papers without fully
+        # processed figure metadata can still be persisted safely.
         if self.figures is not None:
             for i in range(len(self.figures)):
-                img = Image.open(self.figures[i])
+                img = self.figures[i]
+                if isinstance(img, str):
+                    img = Image.open(img)
+
                 img_byte_arr = io.BytesIO()
                 img.save(img_byte_arr, format="JPEG")
                 img_bytes = img_byte_arr.getvalue()
-                figure_stms = insert(figures_table.c.paper_id, figures_table.c.image_blob,
-                                     figures_table.c.ai_caption,
-                                     figures_table.c.figure_embeddings,
-                                     figures_table.c.figure_interpretation_embeddings).values(paper_id,
-                                                                                              img_bytes,
-                                                                                              self.figure_interpretation[
-                                                                                                  i],
-                                                                                              json.dumps(
-                                                                                                  self.figure_embeddings[
-                                                                                                      i].tolist()),
-                                                                                              self.figure_interpretation_embeddings[
-                                                                                                  i]
-                                                                                              )
-                project.kb.session().execute(figure_stms)
+                
+                caption=""
+                if self.figure_interpretation is not None and i < len(self.figure_interpretation):
+                    caption = self.figure_interpretation[i]
 
+                image_embedding = None
+                if self.figure_embeddings is not None and i < len(self.figure_embeddings):
+                    image_embedding = self.figure_embeddings[i]
+                    if hasattr(image_embedding, "tolist"):
+                        image_embedding = image_embedding.tolist()
+
+                caption_embedding = None
+                if self.figure_interpretation_embeddings is not None and i < len(self.figure_interpretation_embeddings):
+                    caption_embedding = self.figure_interpretation_embeddings[i]
+                    if hasattr(caption_embedding, "tolist"):
+                        caption_embedding = caption_embedding.tolist()
+
+                figure_stms = insert(figures_table).values(
+                    paper_id=paper_id,
+                    image_blob=img_bytes,
+                    ai_caption=caption,
+                    # The old PaperInfo persistence used figure-specific column
+                    # names. The current schema normalizes these to
+                    # image_embeddings / ai_caption_embeddings.
+                    image_embeddings=image_embedding,
+                    ai_caption_embeddings=caption_embedding,
+                )
+                project.kb.session.execute(figure_stms)
+
+        # The previous version made the same assumptions for tables as figures: image
+        # paths only, plus older embedding column names. The current
+        # version may provide either file paths or already-loaded images, so
+        # the type check keeps both representations valid. The
+        # guards are there because it maybe possible that table interpretations and embeddings are not
+        # existing yet even when the table image itself was extracted.
         if self.tables is not None:
             for i in range(len(self.tables)):
-                img = Image.open(self.tables[i])
+                img = self.tables[i]
+                if isinstance(img, str):
+                    img = Image.open(img)
+
                 img_byte_arr = io.BytesIO()
                 img.save(img_byte_arr, format="JPEG")
                 img_bytes = img_byte_arr.getvalue()
-                table_smts = insert(tables_table.c.paper_id, tables_table.c.image_blob,
-                                    tables_table.c.ai_caption,
-                                    tables_table.c.table_embeddings,
-                                    tables_table.c.table_interpretation_embeddings).values(paper_id,
-                                                                                           img_bytes,
-                                                                                           self.table_interpretation[
-                                                                                               i],
-                                                                                           json.dumps(
-                                                                                               self.table_embeddings[
-                                                                                                   i].tolist()),
-                                                                                           self.table_interpretation_embeddings[
-                                                                                               i]
-                                                                                           )
-                project.kb.session().execute(table_smts)
 
-        if self.text is not None:
-            text_stms = insert(body_text_table.c.paper_id, body_text_table.c.text, ).values(paper_id, self.text)
-            project.kb.session().execute(text_stms)
+                caption=""
+                if self.table_interpretation is not None and i < len(self.table_interpretation):
+                    caption = self.table_interpretation[i]
 
-        if self.text_chunks is not None:
-            for i in range(len(self.text_chunks)):
-                chunk_stms = insert(chunked_text_table.c.paper_id, chunked_text_table.c.chunk,
-                                    chunked_text_table.c.chunk_embeddings).values(paper_id,
-                                                                                  self.text_chunks[i],
-                                                                                  self.chunk_embeddings[i].tolist())
-                project.kb.session().execute(chunk_stms)
+                image_embedding = None
+                if self.table_embeddings is not None and i < len(self.table_embeddings):
+                    image_embedding = self.table_embeddings[i]
+                    if hasattr(image_embedding, "tolist"):
+                        image_embedding = image_embedding.tolist()
+
+                caption_embedding = None
+                if self.table_interpretation_embeddings is not None and i < len(self.table_interpretation_embeddings):
+                    caption_embedding = self.table_interpretation_embeddings[i]
+                    if hasattr(caption_embedding, "tolist"):
+                        caption_embedding = caption_embedding.tolist()
+
+                table_stms = insert(tables_table).values(
+                    paper_id=paper_id,
+                    image_blob=img_bytes,
+                    ai_caption=caption,
+                    image_embeddings=image_embedding,
+                    ai_caption_embeddings=caption_embedding,
+                )
+                project.kb.session.execute(table_stms)
+
+        # Search works over chunk rows. If the processor has not produced
+        # text_chunks yet, fall back to full text, then abstract, so every
+        # searchable paper still gets at least one chunk row.
+        if self.text_chunks:
+            chunks = list(self.text_chunks)
+        elif self.text:
+            chunks = [self.text]
+        elif self.abstract:
+            chunks = [self.abstract]
+        else:
+            chunks = []
+
+        # protect against duplicate chunk rows
+        existing_chunks = select(chunked_text_table.c.id).where(
+            chunked_text_table.c.paper_id == paper_id
+        ).limit(1)
+
+        has_chunks = project.kb.session.execute(existing_chunks).scalar() is not None
+
+        if not has_chunks:
+            for index, chunk_text in enumerate(chunks):
+                embedding = None
+                if self.chunk_embeddings is not None and index < len(self.chunk_embeddings):
+                    embedding = self.chunk_embeddings[index]
+                    # pgvector accepts plain Python lists more reliably than raw
+                    # numpy arrays, so normalize model outputs before insert.
+                    if hasattr(embedding, "tolist"):
+                        embedding = embedding.tolist()
+
+                chunk_stms = insert(chunked_text_table).values(
+                    paper_id=paper_id,
+                    chunk_id=index,
+                    chunk_text=chunk_text,
+                    chunk_embeddings=embedding,
+                )
+                project.kb.session.execute(chunk_stms)
+
+        # The original logic inserted references once the target paper was found or
+        # created, but it did not check whether the reference itself already existed. These
+        # checks now do the following:
+        # if the referenced paper is not yet in the KB, persist it first
+        # if the reference already exists, do not insert a duplicate row
 
         if self.references is not None:
             for paper in self.references:
-                existing = select(papers_table.c.paper_id).where(papers_table.c.source_id == paper.id,
-                                                                 papers_table.c.id_type == paper.id_type)
-                ref_id = project.kb.session().execute(existing).scalar()
+                existing = select(papers_table.c.id).where(
+                    papers_table.c.source_id == paper.info.id,
+                    papers_table.c.source == paper.info.id_type,
+                )
+                ref_id = project.kb.session.execute(existing).scalar()
+
                 if ref_id is None:
-                    ref_id = project.add_papers(paper)
-                stms = insert(references_table.c.paper_id, references_table.c.id, ).values(paper_id, ref_id)
-                project.kb.session().execute(stms)
+                    ref_id = paper.info.to_kb(project)
 
+                existing_relation = select(references_table.c.id).where(
+                    references_table.c.source_id == paper_id,
+                    references_table.c.target_id == ref_id,
+                ).limit(1)
+
+                if project.kb.session.execute(existing_relation).scalar() is None:
+                    stms = insert(references_table).values(
+                        source_id=paper_id,
+                        target_id=ref_id,
+                    )
+                    project.kb.session.execute(stms)
+
+        # This follows the same pattern as references.
         if self.related_works is not None:
-            for paper in self.related_works:  #
-                existing = select(papers_table.c.paper_id).where(papers_table.c.source_id == paper.id,
-                                                                 papers_table.c.id_type == paper.id_type)
-                related_id = project.kb.session().execute(existing).scalar()
-                if related_id is None:
-                    related_id = project.add_papers(paper)
-                stms = insert(related_works_table.c.paper_id, related_works_table.c.id, ).values(paper_id, related_id)
-                project.kb.session().execute(stms)
+            for paper in self.related_works:
+                existing = select(papers_table.c.id).where(
+                    papers_table.c.source_id == paper.info.id,
+                    papers_table.c.source == paper.info.id_type,
+                )
+                related_id = project.kb.session.execute(existing).scalar()
 
+                if related_id is None:
+                    related_id = paper.info.to_kb(project)
+
+                existing_relation = select(related_works_table.c.id).where(
+                    related_works_table.c.source_id == paper_id,
+                    related_works_table.c.target_id == related_id,
+                ).limit(1)
+
+                if project.kb.session.execute(existing_relation).scalar() is None:
+                    stms = insert(related_works_table).values(
+                        source_id=paper_id,
+                        target_id=related_id,
+                    )
+                    project.kb.session.execute(stms)
+
+        # Adds explicit existence checks that the previous version did not have. One check ensures the
+        # cited paper is persisted before linking to it, and the other prevents duplicate
+        # source_id : target_id rows if this paper is written to the KB more than once.
         if self.cited_by is not None:
             for paper in self.cited_by:
-                existing = select(papers_table.c.paper_id).where(papers_table.c.source_id == paper.id,
-                                                                 papers_table.c.id_type == paper.id_type)
-                cited_id = project.kb.session().execute(existing).scalar()
-                if cited_id is None:
-                    cited_id = project.add_papers(paper)
-                stms = insert(cited_by_table.c.paper_id, cited_by_table.c.id, ).values(paper_id, cited_id)
-                project.kb.session().execute(stms)
+                existing = select(papers_table.c.id).where(
+                    papers_table.c.source_id == paper.info.id,
+                    papers_table.c.source == paper.info.id_type,
+                )
+                cited_id = project.kb.session.execute(existing).scalar()
 
-        project.kb.session().commit()
+                if cited_id is None:
+                    cited_id = paper.info.to_kb(project)
+
+                existing_relation = select(cited_by_table.c.id).where(
+                    cited_by_table.c.source_id == paper_id,
+                    cited_by_table.c.target_id == cited_id,
+                ).limit(1)
+
+                if project.kb.session.execute(existing_relation).scalar() is None:
+                    stms = insert(cited_by_table).values(
+                        source_id=paper_id,
+                        target_id=cited_id,
+                    )
+                    project.kb.session.execute(stms)
+
+        project.kb.session.commit()
         return paper_id
 
 
@@ -173,20 +307,20 @@ class PaperInfo:
             papers_table.c.title,
             papers_table.c.abstract,
             papers_table.c.abstract_embeddings,
-            papers_table.c.text,
+            papers_table.c.full_text,
             papers_table.c.pdf_url,
             papers_table.c.pdf_path,
             papers_table.c.openalex_response,
             papers_table.c.authors,
-        ).where(papers_table.c.paper_id == id)
-        paper_info = project.kb.session().execute(selection).fetchall()
+        ).where(papers_table.c.id == id)
+        paper_info = project.kb.session.execute(selection).fetchall()
 
         if len(paper_info) > 1:
             raise DataIntegrityError("There are multiple papers with the id {}".format(id))
         elif len(paper_info) == 0:
             raise NoResultFound("Could not find a paper with id:{}".format(id))
         else:
-            paper = cls(paper_id=paper_info[0][0], id_type=paper_info[0][1], get_abstract=False)
+            paper = cls(id=paper_info[0][0], id_type=paper_info[0][1])
             paper.title = paper_info[0][2]
             paper.abstract = paper_info[0][3]
             paper.abstract_embeddings = paper_info[0][4]
@@ -197,14 +331,14 @@ class PaperInfo:
                 paper.downloaded = True
             else:
                 paper.downloaded = False
-            paper.openalex_response = paper_info[0][8]
+            paper.openalex_info = paper_info[0][8]
             paper.authors = paper_info[0][9]
 
         figures = select(figures_table.c.image_blob,
-                         figures_table.c.figure_embeddings,
+                         figures_table.c.image_embeddings,
                          figures_table.c.ai_caption,
-                         figures_table.c.figure_interpretation_embeddings).where(figures_table.c.paper_id == id)
-        figures = project.kb.session().execute(figures).fetchall()
+                         figures_table.c.ai_caption_embeddings).where(figures_table.c.paper_id == id)
+        figures = project.kb.session.execute(figures).fetchall()
         if len(figures) == 0:
             paper.figures = None
         else:
@@ -214,10 +348,10 @@ class PaperInfo:
             paper.figure_interpretation_embeddings = [figure[3] for figure in figures]
 
         tables = select(tables_table.c.image_blob,
-                        tables_table.c.table_embeddings,
+                        tables_table.c.image_embeddings,
                         tables_table.c.ai_caption,
-                        tables_table.c.table_interpretation_embeddings).where(tables_table.c.paper_id == id)
-        tables = project.kb.session().execute(tables).fetchall()
+                        tables_table.c.ai_caption_embeddings).where(tables_table.c.paper_id == id)
+        tables = project.kb.session.execute(tables).fetchall()
         if len(tables) == 0:
             paper.tables = None
         else:
@@ -226,45 +360,46 @@ class PaperInfo:
             paper.table_interpretation = [table[2] for table in tables]
             paper.table_interpretation_embeddings = [table[3] for table in tables]
 
-        chunks = select(chunked_text_table.c.chunk,
-                        chunked_text_table.c.chunk_embeddings).where(chunked_text_table.c.paper_id == id)
-        chunks = project.kb.session().execute(chunks).fetchall()
+        chunks = (select(chunked_text_table.c.chunk_text,
+                        chunked_text_table.c.chunk_embeddings).where(chunked_text_table.c.paper_id == id).order_by(chunked_text_table.c.chunk_id)
+                        )
+        chunks = project.kb.session.execute(chunks).fetchall()
         if len(chunks) == 0:
             paper.text_chunks = None
         else:
             paper.text_chunks = [chunk[0] for chunk in chunks]
             paper.chunk_embeddings = [chunk[1] for chunk in chunks]
 
-        references = select(references_table.c.target_id).where(references_table.c.paper_id == id)
-        references = project.kb.session().execute(references).fetchall()
+        references = select(references_table.c.target_id).where(references_table.c.source_id == id)
+        references = project.kb.session.execute(references).fetchall()
         if len(references) == 0:
             paper.references = None
         else:
             refs = []
             for ref in references:
-                ref_paper = cls.from_kb(project, ref[1])
+                ref_paper = cls.from_kb(project, ref[0])
                 refs.append(ref_paper)
             paper.references = refs
 
-        cited_by = select(cited_by_table.c.target_id).where(cited_by_table.c.paper_id == id)
-        cited_by = project.kb.session().execute(cited_by).fetchall()
+        cited_by = select(cited_by_table.c.target_id).where(cited_by_table.c.source_id == id)
+        cited_by = project.kb.session.execute(cited_by).fetchall()
         if len(cited_by) == 0:
             paper.cited_by = None
         else:
             refs = []
             for ref in cited_by:
-                ref_paper = cls.from_kb(project, ref[1])
+                ref_paper = cls.from_kb(project, ref[0])
                 refs.append(ref_paper)
             paper.cited_by = refs
 
-        related_works = select(related_works_table.c.target_id).where(related_works_table.c.paper_id == id)
-        related_works = project.kb.session().execute(related_works).fetchall()
+        related_works = select(related_works_table.c.target_id).where(related_works_table.c.source_id == id)
+        related_works = project.kb.session.execute(related_works).fetchall()
         if len(related_works) == 0:
             paper.related_works = None
         else:
             refs = []
             for ref in related_works:
-                ref_paper = cls.from_kb(project, ref[1])
+                ref_paper = cls.from_kb(project, ref[0])
                 refs.append(ref_paper)
             paper.related_works = refs
 

--- a/benchmate/molecule/molecule.py
+++ b/benchmate/molecule/molecule.py
@@ -10,7 +10,7 @@ from rdkit.Chem import Descriptors
 from rdkit.Chem import rdMolDescriptors
 from rdkit.Chem.rdFingerprintGenerator import GetMorganGenerator, GetMorganFeatureAtomInvGen
 
-from benchmate.project.utils import DataIntegrityError
+from benchmate.utils.general_utils import DataIntegrityError
 from benchmate.molecule.utils import *
 
 

--- a/benchmate/project/project.py
+++ b/benchmate/project/project.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import yaml
 from functools import cached_property, partial
+from datetime import datetime
 
 from openai import project
 from sqlalchemy import select, insert, create_engine
@@ -48,8 +49,10 @@ class Project:
 
         #modules
         self.literature=Literature(self.config["literature"], inference=self.inference)
-        self.apis=Apis(self.config["apis"])
-        self.alignment=Alignment(self.config["alignment"])
+        #self.apis=Apis(self.config["api"])
+        #self.alignment=Alignment(self.config["alignment"])
+        self.apis=None
+        self.alignment=None
 
         #here we use these instances it's always project.this or project.that
         self.molecule=Molecule
@@ -67,13 +70,15 @@ class Project:
 
     def _project_create(self):
         project_table=self.kb.db_tables["project"]
-        query=select(project_table.c.project_id).filter(project_table.c.name==self.name)
-        results=self.kb.session().execute(query).fetchall()
+        query=select(project_table.c.id).filter(project_table.c.name==self.name) # key column in tables.py is "id" not "project_id" 
+        results=self.kb.session.execute(query).fetchall() #session is an object, not a factory function, using instead of session() so there is only one session object
 
         if len(results)==0:
+            now = datetime.now()
             ins=insert(project_table).values(name=self.name,
-                                             description=self.description).returning(project_table.c.project_id)
-            self.project_id=self.kb.session().execute(ins).scalar()
+                                             description=self.description,created_at=now,updated_at=now).returning(project_table.c.id) # Project class in tables.py has created_at and updated_at
+            self.project_id=self.kb.session.execute(ins).scalar()
+            self.kb.session.commit() # new project row presists right away
         elif len(results)==1:
             self.project_id=results[0][0]
         else:

--- a/benchmate/project/search.py
+++ b/benchmate/project/search.py
@@ -1,6 +1,156 @@
+from sqlalchemy import asc, select, cast
+from pgvector.sqlalchemy import Vector
+
 class Search:
     def __init__(self, project, inference):
-        pass
+        """
+        Initialize a project-scoped search helper.
+
+        :param project: Project object that owns the reflected knowledge-base
+            tables and SQLAlchemy session.
+        :type project: Project
+        :param inference: Inference helper used to embed natural-language
+            queries into the same vector space as stored chunk embeddings.
+        :type inference: Inference
+        """
+        # Search needs both the current project/KB session and an inference object
+        # that can embed natural-language queries
+        self.project = project
+        self.inference = inference
+        self.session = project.kb.session
 
     def search(self, what, search_dict):
-        pass
+        """
+        Dispatch a search request to the appropriate search backend.
+
+        :param what: Search target identifier. Currently supports
+            `"papers"` and `"literature"`.
+        :type what: str
+        :param search_dict: Search configuration dictionary. For semantic paper
+            search this should contain at least a `query` key and may also
+            include `metric`, `limit`, or `top_k`.
+        :type search_dict: dict
+        :return: Search results for the requested target.
+        :rtype: list[dict]
+        :raises NotImplementedError: If the requested search target is not supported.
+        """
+        # Keep the entry point generic so other search targets can be
+        # added later. For now, literature search jsut means semantic paper search.
+        if what in ["papers", "literature"]:
+            return self._paper_semantic_search(search_dict)
+
+        raise NotImplementedError(f"Search for {what} is not implemented")
+
+    def _paper_semantic_search(self, search_dict):
+        """
+        Run semantic search over stored paper chunks.
+
+        The query is embedded with the configured inference backend, compared
+        against `body_text_chunked.chunk_embeddings` using pgvector distance
+        operators, and then joined back to `papers` so each hit includes the
+        associated paper metadata.
+
+        :param search_dict: Semantic search configuration. Expected keys:
+            `query` (required), plus optional `metric`, `limit`, or
+            `top_k`.
+        :type search_dict: dict
+        :return: Chunk-level search hits with paper metadata, raw distance, and
+            a derived score.
+        :rtype: list[dict]
+        :raises ValueError: If an unsupported metric is requested.
+        """
+        # Required natural-language query plus some optional search
+        # controls. top_k is accepted as alt for limit.
+        query = search_dict["query"]
+        metric = search_dict.get("metric", "cosine")
+        limit = search_dict.get("limit", search_dict.get("top_k", 10))
+
+        # Convert the query text into the same vector space used for stored
+        # chunks. pgvector accepts plain Python lists, so convert numpy arrays.
+        query_vec = self.inference.embed_text([query])[0]
+        if hasattr(query_vec, "tolist"):
+            query_vec = query_vec.tolist()
+
+        # papers stores paper metadata; body_text_chunked stores the
+        # searchable text units and their embeddings.
+        papers_table = self.project.kb.db_tables["papers"]
+        chunks_table = self.project.kb.db_tables["body_text_chunked"]
+
+        # The KB reflects tables from Postgres, so cast the reflected column back
+        # to Vector(1024) to make pgvector distance helpers available reliably.
+        embedding_col = cast(chunks_table.c.chunk_embeddings, Vector(1024))
+
+        # Mostly from the CHIRPP semantic-query logic: choose the
+        # pgvector distance from the requested metric, then order by
+        # the resulting expression. pgvector distance operators sort with the
+        # best match first when ordered ascending. For cosine, 
+        # score where higher is better.
+        if metric == "cosine":
+            distance = embedding_col.cosine_distance(query_vec)
+            order = asc(distance)
+            score_from_distance = lambda value: 1.0 - float(value)
+        elif metric in ["L2", "l2"]:
+            distance = embedding_col.l2_distance(query_vec)
+            order = asc(distance)
+            score_from_distance = lambda value: -float(value)
+        elif metric in ["L1", "l1"]:
+            distance = embedding_col.l1_distance(query_vec)
+            order = asc(distance)
+            score_from_distance = lambda value: -float(value)
+        elif metric == "max_inner_product":
+            distance = embedding_col.max_inner_product(query_vec)
+            order = asc(distance)
+            score_from_distance = lambda value: -float(value)
+        else:
+            raise ValueError(f"Invalid metric: {metric}")
+
+        distance = distance.label("distance")
+
+        # Search chunks first, then join back to papers so each hit includes
+        # paper metadata. The project filter prevents hits from unrelated
+        # projects, and the embedding filter skips chunks that have not been
+        # embedded yet.
+        stmt = (
+            select(
+                papers_table.c.id.label("paper_id"),
+                papers_table.c.source,
+                papers_table.c.source_id,
+                papers_table.c.title,
+                papers_table.c.abstract,
+                papers_table.c.pdf_url,
+                papers_table.c.pdf_path,
+                chunks_table.c.chunk_id,
+                chunks_table.c.chunk_text,
+                distance,
+            )
+            .select_from(
+                chunks_table.join(
+                    papers_table,
+                    chunks_table.c.paper_id == papers_table.c.id,
+                )
+            )
+            .where(papers_table.c.project_id == self.project.project_id)
+            .where(chunks_table.c.chunk_embeddings.isnot(None))
+            .order_by(order)
+            .limit(limit)
+        )
+
+        rows = self.session.execute(stmt).fetchall()
+
+        # Return plain dictionaries.
+        return [
+            {
+                "paper_id": row.paper_id,
+                "source": row.source,
+                "source_id": row.source_id,
+                "title": row.title,
+                "abstract": row.abstract,
+                "open_access": row.pdf_url is not None,
+                "downloaded": row.pdf_path is not None,
+                "chunk_id": row.chunk_id,
+                "chunk_text": row.chunk_text,
+                "distance": float(row.distance),
+                "score": score_from_distance(row.distance),
+            }
+            for row in rows
+        ]


### PR DESCRIPTION
**Summary**
Moves the paper persistence path from `PaperInfo` into `Paper`, aligns the literature DB logic with the current KB schema, and adds a first semantic paper search path.

- Updated project creation flow in [`project.py`](https://github.com/ccmbioinfo/ccm_benchmate/blob/master/benchmate/project/project.py)
  - uses `project.id` instead of stale `project_id`
  - inserts required `created_at` / `updated_at`
  - uses the live SQLAlchemy session correctly

- Moved paper persistence into [`literature.py`](https://github.com/ccmbioinfo/ccm_benchmate/blob/master/benchmate/literature/literature.py)
  - added `Paper.to_kb(project)`
  - added `Paper.from_kb(project, id, load_relations=True)`

- `Paper.to_kb()` now stores:
  - paper metadata in `papers`
  - text chunks in `body_text_chunked`
  - references in `references`
  - related works in `related_works`
  - cited-by links in `cited_by`
  - figures in `figures`
  - tables in `tables`

- `Paper.from_kb()` now restores:
  - paper metadata
  - chunks
  - references
  - related works
  - cited-by
  - figures
  - tables

- Added relation recursion guard in [`literature.py`](https://github.com/ccmbioinfo/ccm_benchmate/blob/master/benchmate/literature/literature.py)
  - nested relation loads use `load_relations=False`

- Added docstrings and inline comments in:
  - [`literature.py`](https://github.com/ccmbioinfo/ccm_benchmate/blob/master/benchmate/literature/literature.py)
  - [`search.py`](https://github.com/ccmbioinfo/ccm_benchmate/blob/master/benchmate/project/search.py)

- Added a semantic paper search implementation in [`search.py`](https://github.com/ccmbioinfo/ccm_benchmate/blob/master/benchmate/project/search.py)
  - embeds natural-language query
  - searches `body_text_chunked.chunk_embeddings`
  - joins back to `papers`
  - returns chunk-level hits with paper metadata and score/distance

**Notes**
- Canonical persistence path is now:
  - `paper.to_kb(project)`
  - `Paper.from_kb(project, paper_id)`

- `PaperInfo` is effectively being treated as a data container now.
- The old DB methods still remain in [`paperinfo.py`](https://github.com/ccmbioinfo/ccm_benchmate/blob/master/benchmate/literature/paperinfo.py), but they are stale and should likely be removed or replaced with explicit stubs indicating the logic has moved to `Paper`.

- Some inline comments were added to make schema/logical differences and search functionality clearer for me during development.
- These can be reduced/cleaned later once the implementation is settled.

**Testing done**
- abstract-only paper save/load
- references / related works / cited-by save/load
- semantic search test using stored chunk embeddings



**ToDo**
- figures and tables persistence/load paths have been moved over, using the same logic as before, but have not really been tested yet
- full-text search testing needs to be tested explicitly
  - abstract-based search has been tested, and full-text should follow same logic
  - but this still needs confirmed testing
- Remove or deprecate old DB methods in [`paperinfo.py`](https://github.com/ccmbioinfo/ccm_benchmate/blob/master/benchmate/literature/paperinfo.py)
- Add documentation for how to use:
  - `Paper.to_kb()`
  - `Paper.from_kb()`
  - semantic search via `Search`
  - update literature documentation in general
- Update Docker Hub containers to the correct version matching this code and libgl installs 
